### PR TITLE
restore boolean return type of VariablesLua.varexists

### DIFF
--- a/lua/mw.ext.VariablesLua.lua
+++ b/lua/mw.ext.VariablesLua.lua
@@ -41,8 +41,9 @@ end
 function VariablesLua.varexists( name )
 	libraryUtil.checkTypeMulti( 'varexists', 1, name, { 'string', 'number' } )
 	name = tostring( name )
+    local exists = php.varexists( name )
 
-	return php.varexists( name )
+	return exists and exists ~= ""
 end
 
 function VariablesLua.setupInterface( options )


### PR DESCRIPTION
Sometime between versions 2.4.0 and 2.5.1 of the Variables extension (I can narrow it down further if interested), the return value of `ExtVariables::pfObj_varexists()` changed from boolean true/false to the strings "1"/"". While this does more closely resemble what happens in the wikicode of an article that calls the parser function `{{#varexists:...}}`, these new return values are a bit less useful in Lua.

The problem stems from the fact that the empty string is a truthy value in Lua. Code that was previously written like this:

```
if mw.ext.VariablesLua.varexists("varname") then
    -- true branch
else
    -- false branch
end
```

will become broken and always take the true branch.

This PR restores the boolean true/false return type to `VariablesLua.varexists`. It does so in a way that is backwards compatible such that both the new and previous behavior of the Variables extension will result in the correct return value.