### PR TITLE
Fix vardefine and vardefineecho

### DIFF
--- a/src/ScribuntoLuaLibrary.php
+++ b/src/ScribuntoLuaLibrary.php
@@ -35,13 +35,25 @@ class ScribuntoLuaLibrary extends Scribunto_LuaLibraryBase {
 	public function fnVardefine() {
 		$params = func_get_args();
 		$parser = $this->getParser();
-		return [ ExtVariables::pf_vardefine( $parser, ...$params ) ];
+		if ( method_exists( 'ExtVariables', 'pfObj_vardefine' ) ) {
+			return [ ExtVariables::pfObj_vardefine(
+					$parser, $parser->getPreprocessor()->newFrame(), $params
+				) ];
+		} else {
+			return [ ExtVariables::pf_vardefine( $parser, ...$params ) ];
+		}
 	}
 
 	public function fnVardefineecho() {
 		$params = func_get_args();
 		$parser = $this->getParser();
-		return [ ExtVariables::pf_vardefineecho( $parser, ...$params ) ];
+		if ( method_exists( 'ExtVariables', 'pfObj_vardefineecho' ) ) {
+			return [ ExtVariables::pfObj_vardefineecho(
+					$parser, $parser->getPreprocessor()->newFrame(), $params
+				) ];
+		} else {
+			return [ ExtVariables::pf_vardefineecho( $parser, ...$params ) ];
+		}
 	}
 
 	public function fnVarexists() {


### PR DESCRIPTION
In Variables commit [919e398](https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Variables/+/919e398a752fce9d9e11c17b6dd08cb7969aaf65%5E%21/), they changed the functions for vardefine and vardefineecho. This patch uses the new ones if available, and falls back to the older ones if not.

Miraheze Bug: https://issue-tracker.miraheze.org/T12369